### PR TITLE
user version 0.2.1 from ember-cli-node-webkit instead of 0.2.0 and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You will need the following things properly installed on your computer.
 
 ## Installation
 
-* `git clone git@github.com:uhura/uhura-dashboard.git` this repository
+* clone this repository: `git clone git@github.com:uhuraapp/uhura-frontend.git`
 * change into the new directory
 * `npm install`
 * `bower install`

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-mirage": "0.1.4",
-    "ember-cli-node-webkit": "0.2.0",
+    "ember-cli-node-webkit": "0.2.1",
     "ember-cli-qunit": "0.3.13",
     "ember-cli-release": "0.2.3",
     "ember-cli-sass": "3.2.0",


### PR DESCRIPTION
I don't know why, but version 0.2.0 is not installing. Version 0.2.1 is basically 0.2.0 [according to the maintainer](https://github.com/brzpegasus/ember-cli-node-webkit/releases#0.2.1).